### PR TITLE
chore: migrate golangci-lint to v2 and bump Go to 1.26.3

### DIFF
--- a/.github/workflows/best-practices-ci.yml
+++ b/.github/workflows/best-practices-ci.yml
@@ -39,9 +39,9 @@ jobs:
     name: fmt + mod hygiene
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: best-practices/go.mod
           cache: true
@@ -83,8 +83,8 @@ jobs:
     name: golangci-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: best-practices/go.mod
           cache: true
@@ -105,8 +105,8 @@ jobs:
     name: tests (race + coverage)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: best-practices/go.mod
           cache: true
@@ -132,14 +132,14 @@ jobs:
 
       - name: Upload JUnit
         if: always()
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: junit
           path: best-practices/junit.xml
 
       - name: Upload coverage
         if: always()
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage
           path: best-practices/coverage.out
@@ -151,7 +151,7 @@ jobs:
     name: govulncheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
         with:
           work-dir: best-practices/good
@@ -167,8 +167,8 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: best-practices/go.mod
           cache: true
@@ -182,7 +182,7 @@ jobs:
         run: gosec -no-fail -fmt sarif -out gosec.sarif ./best-practices/good/...
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@4e828ff8d448a8a6e532957b1811f387a63867e8 # v3.27.5
+        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         with:
           sarif_file: gosec.sarif
 
@@ -193,7 +193,7 @@ jobs:
     name: gitleaks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
@@ -207,7 +207,7 @@ jobs:
     name: sbom + grype
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Generate SBOM
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
@@ -224,7 +224,7 @@ jobs:
           severity-cutoff: high
 
       - name: Upload SBOM
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sbom
           path: sbom.cdx.json
@@ -240,11 +240,11 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: github/codeql-action/init@4e828ff8d448a8a6e532957b1811f387a63867e8 # v3.27.5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         with:
           languages: go
-      - uses: github/codeql-action/analyze@4e828ff8d448a8a6e532957b1811f387a63867e8 # v3.27.5
+      - uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
 
   # ---------------------------------------------------------------------------
   # 9. Aggregate gate - branch protection points at this single check.

--- a/.github/workflows/best-practices-ci.yml
+++ b/.github/workflows/best-practices-ci.yml
@@ -156,6 +156,7 @@ jobs:
         with:
           work-dir: best-practices/good
           go-version-file: best-practices/go.mod
+          repo-checkout: false
 
   # ---------------------------------------------------------------------------
   # 5. gosec - Go security smells, results uploaded as SARIF.

--- a/.github/workflows/test_all.yml
+++ b/.github/workflows/test_all.yml
@@ -13,7 +13,7 @@ jobs:
       projects: ${{ steps.find-projects.outputs.projects }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Find Go projects
         id: find-projects
         run: |
@@ -28,9 +28,9 @@ jobs:
         project: ${{ fromJson(needs.find-projects.outputs.projects) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: ${{ matrix.project }}/go.mod
           cache-dependency-path: ${{ matrix.project }}/go.sum

--- a/.github/workflows/test_all.yml
+++ b/.github/workflows/test_all.yml
@@ -17,9 +17,7 @@ jobs:
       - name: Find Go projects
         id: find-projects
         run: |
-          # best-practices/ has its own dedicated CI (best-practices-ci.yml) and
-          # targets Go 1.26 which requires golangci-lint v2 — excluded here.
-          projects=$(find . -type f -name 'go.mod' -not -path './best-practices/*' -exec dirname {} \; | jq -R . | jq -s . | jq -c .)
+          projects=$(find . -type f -name 'go.mod' -exec dirname {} \; | jq -R . | jq -s . | jq -c .)
           echo "projects=$projects" >> $GITHUB_OUTPUT
 
   test-and-lint:
@@ -37,9 +35,9 @@ jobs:
           go-version-file: ${{ matrix.project }}/go.mod
           cache-dependency-path: ${{ matrix.project }}/go.sum
       - name: Run lint
-        uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837 # v6.5.0
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: v1.64.8
+          version: latest
           working-directory: ${{ matrix.project }}
       - name: Run tests
         run: |

--- a/.github/workflows/test_all.yml
+++ b/.github/workflows/test_all.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Find Go projects
         id: find-projects
         run: |
-          projects=$(find . -type f -name 'go.mod' -exec dirname {} \; | jq -R . | jq -s . | jq -c .)
+          projects=$(find . -type f -name 'go.mod' -not -path './best-practices/*' -exec dirname {} \; | jq -R . | jq -s . | jq -c .)
           echo "projects=$projects" >> $GITHUB_OUTPUT
 
   test-and-lint:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,9 +1,6 @@
+version: "2"
 linters:
-  # Disable all linters.
-  # Default: false
-  disable-all: true
-  # Enable specific linter
-  # https://golangci-lint.run/usage/linters/#enabled-by-default
+  default: none
   enable:
     - asasalint
     - asciicheck
@@ -15,25 +12,19 @@ linters:
     - copyloopvar
     - cyclop
     - decorder
-    # - depguard
     - dogsled
     - dupl
     - dupword
     - durationcheck
-    # - err113
     - errcheck
     - errchkjson
     - errname
     - errorlint
-    # - execinquery
     - exhaustive
-    # - exhaustruct
-    # - exportloopref
     - fatcontext
     - forbidigo
     - forcetypeassert
     - funlen
-    # - gci
     - ginkgolinter
     - gocheckcompilerdirectives
     - gochecknoglobals
@@ -45,15 +36,11 @@ linters:
     - gocyclo
     - godot
     - godox
-    - gofmt
-    # - gofumpt
     - goheader
-    - goimports
     - gomoddirectives
     - gomodguard
     - goprintffuncname
     - gosec
-    - gosimple
     - gosmopolitan
     - govet
     - grouper
@@ -75,12 +62,10 @@ linters:
     - nestif
     - nilerr
     - nilnil
-    # - nlreturn
     - noctx
     - nolintlint
     - nonamedreturns
     - nosprintfhostport
-    # - paralleltest
     - perfsprint
     - prealloc
     - predeclared
@@ -93,22 +78,37 @@ linters:
     - spancheck
     - sqlclosecheck
     - staticcheck
-    - stylecheck
     - tagalign
     - tagliatelle
-    - tenv
     - testableexamples
     - testifylint
-    # - testpackage
     - thelper
     - tparallel
     - unconvert
     - unparam
     - unused
     - usestdlibvars
-    # - varnamelen
     - wastedassign
     - whitespace
-    # - wrapcheck
-    # - wsl
     - zerologlint
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,7 +38,7 @@ linters:
     - godox
     - goheader
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
     - gosmopolitan

--- a/fiber-postgres/app/config_test.go
+++ b/fiber-postgres/app/config_test.go
@@ -21,7 +21,7 @@ func TestNewConfiguration_Defaults(t *testing.T) {
 	conf := newConfiguration()
 
 	assert.Equal(t, "3000", conf.Port)
-	assert.Equal(t, "", conf.DatabaseURL)
+	assert.Empty(t, conf.DatabaseURL)
 }
 
 func TestGetEnvOrDefault(t *testing.T) {

--- a/fiber-postgres/app/datasources/database/postgres_db_test.go
+++ b/fiber-postgres/app/datasources/database/postgres_db_test.go
@@ -9,13 +9,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const testBookTitle = "book1"
+
 func TestPostgresDB_GetBooks(t *testing.T) {
 	mockPool, err := pgxmock.NewPool()
 	require.NoError(t, err)
 
 	mockPool.ExpectQuery("SELECT id, title FROM books").
 		WillReturnRows(pgxmock.NewRows([]string{"id", "title"}).
-			AddRow(1, "book1"))
+			AddRow(1, testBookTitle))
 
 	db := postgresDB{
 		pool: mockPool,
@@ -23,7 +25,7 @@ func TestPostgresDB_GetBooks(t *testing.T) {
 	result, err := db.LoadAllBooks(context.Background())
 	require.NoError(t, err)
 	assert.Len(t, result, 1)
-	assertBook(t, result[0], 1, NewBook{Title: "book1"})
+	assertBook(t, result[0], 1, NewBook{Title: testBookTitle})
 
 	require.NoError(t, mockPool.ExpectationsWereMet())
 }
@@ -50,13 +52,13 @@ func TestPostgresDB_CreateBook(t *testing.T) {
 	require.NoError(t, err)
 
 	mockPool.ExpectExec("INSERT INTO books").
-		WithArgs("book1").
+		WithArgs(testBookTitle).
 		WillReturnResult(pgxmock.NewResult("INSERT", 1))
 
 	db := postgresDB{
 		pool: mockPool,
 	}
-	err = db.CreateBook(context.Background(), NewBook{Title: "book1"})
+	err = db.CreateBook(context.Background(), NewBook{Title: testBookTitle})
 	require.NoError(t, err)
 
 	require.NoError(t, mockPool.ExpectationsWereMet())
@@ -67,13 +69,13 @@ func TestPostgresDB_CreateBook_Fail(t *testing.T) {
 	require.NoError(t, err)
 
 	mockPool.ExpectExec("INSERT INTO books").
-		WithArgs("book1").
+		WithArgs(testBookTitle).
 		WillReturnError(assert.AnError)
 
 	db := postgresDB{
 		pool: mockPool,
 	}
-	err = db.CreateBook(context.Background(), NewBook{Title: "book1"})
+	err = db.CreateBook(context.Background(), NewBook{Title: testBookTitle})
 	require.ErrorContains(t, err, "failed to insert book")
 
 	require.NoError(t, mockPool.ExpectationsWereMet())

--- a/fiber-postgres/app/go.mod
+++ b/fiber-postgres/app/go.mod
@@ -1,6 +1,6 @@
 module app
 
-go 1.23.3
+go 1.26.3
 
 require (
 	github.com/gofiber/fiber/v2 v2.52.5

--- a/fiber-postgres/app/server/handlers/books.go
+++ b/fiber-postgres/app/server/handlers/books.go
@@ -9,12 +9,14 @@ import (
 	"github.com/gofiber/fiber/v2"
 )
 
+const errInternal = "internal error"
+
 func GetBooks(service services.BooksService) fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		books, err := service.GetBooks(c.UserContext())
 		if err != nil {
 			slog.Error("GetBooks failed", "error", err)
-			return sendError(c, fiber.StatusInternalServerError, "internal error")
+			return sendError(c, fiber.StatusInternalServerError, errInternal)
 		}
 
 		return c.JSON(domain.BooksResponse{
@@ -35,7 +37,7 @@ func AddBook(service services.BooksService) fiber.Handler {
 		err := service.SaveBook(c.UserContext(), book)
 		if err != nil {
 			slog.Error("AddBook failed", "error", err)
-			return sendError(c, fiber.StatusInternalServerError, "internal error")
+			return sendError(c, fiber.StatusInternalServerError, errInternal)
 		}
 		return c.SendStatus(fiber.StatusCreated)
 	}

--- a/fiber-postgres/app/server/handlers/books_test.go
+++ b/fiber-postgres/app/server/handlers/books_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -25,7 +26,7 @@ func TestGetBooks(t *testing.T) {
 	app := fiber.New()
 	app.Get(booksRoute, GetBooks(mockService))
 
-	resp, err := app.Test(httptest.NewRequest(http.MethodGet, booksRoute, nil))
+	resp, err := app.Test(httptest.NewRequestWithContext(t.Context(), http.MethodGet, booksRoute, nil))
 	require.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
 	defer resp.Body.Close()
@@ -41,7 +42,7 @@ func TestGetBooks_ServiceFails(t *testing.T) {
 	app := fiber.New()
 	app.Get(booksRoute, GetBooks(mockService))
 
-	resp, err := app.Test(httptest.NewRequest(http.MethodGet, booksRoute, nil))
+	resp, err := app.Test(httptest.NewRequestWithContext(t.Context(), http.MethodGet, booksRoute, nil))
 	require.NoError(t, err)
 	assert.Equal(t, 500, resp.StatusCode)
 	defer resp.Body.Close()
@@ -57,7 +58,7 @@ func TestAddBook(t *testing.T) {
 	app := fiber.New()
 	app.Post(booksRoute, AddBook(mockService))
 
-	resp, err := app.Test(postRequest(booksRoute, `{"title":"Title"}`))
+	resp, err := app.Test(postRequest(t.Context(), booksRoute, `{"title":"Title"}`))
 	require.NoError(t, err)
 	assert.Equal(t, 201, resp.StatusCode)
 	defer resp.Body.Close()
@@ -69,7 +70,7 @@ func TestAddBook_InvalidRequest(t *testing.T) {
 	app := fiber.New()
 	app.Post(booksRoute, AddBook(mockService))
 
-	resp, err := app.Test(httptest.NewRequest(http.MethodPost, booksRoute, nil))
+	resp, err := app.Test(httptest.NewRequestWithContext(t.Context(), http.MethodPost, booksRoute, nil))
 	require.NoError(t, err)
 	assert.Equal(t, 400, resp.StatusCode)
 	defer resp.Body.Close()
@@ -85,7 +86,7 @@ func TestAddBook_ServiceFails(t *testing.T) {
 	app := fiber.New()
 	app.Post(booksRoute, AddBook(mockService))
 
-	resp, err := app.Test(postRequest(booksRoute, `{"title":"Title"}`))
+	resp, err := app.Test(postRequest(t.Context(), booksRoute, `{"title":"Title"}`))
 	require.NoError(t, err)
 	assert.Equal(t, 500, resp.StatusCode)
 	defer resp.Body.Close()
@@ -94,8 +95,8 @@ func TestAddBook_ServiceFails(t *testing.T) {
 	assert.Equal(t, "internal error", body.Error)
 }
 
-func postRequest(url string, body string) *http.Request {
-	req := httptest.NewRequest(http.MethodPost, url, bytes.NewBufferString(body))
+func postRequest(ctx context.Context, url string, body string) *http.Request {
+	req := httptest.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBufferString(body))
 	req.Header.Set(fiber.HeaderContentType, fiber.MIMEApplicationJSON)
 	return req
 }

--- a/fiber-postgres/app/server/handlers/books_test.go
+++ b/fiber-postgres/app/server/handlers/books_test.go
@@ -17,11 +17,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const booksRoute = "/api/v1/books"
+const (
+	booksRoute = "/api/v1/books"
+	bookTitle  = "Title"
+)
 
 func TestGetBooks(t *testing.T) {
 	mockService := new(services.MockBooksService)
-	mockService.On("GetBooks", mock.Anything).Return([]domain.Book{{Title: "Title"}}, nil)
+	mockService.On("GetBooks", mock.Anything).Return([]domain.Book{{Title: bookTitle}}, nil)
 
 	app := fiber.New()
 	app.Get(booksRoute, GetBooks(mockService))
@@ -48,12 +51,12 @@ func TestGetBooks_ServiceFails(t *testing.T) {
 	defer resp.Body.Close()
 
 	body := bodyFromResponse[domain.ErrorResponse](t, resp)
-	assert.Equal(t, "internal error", body.Error)
+	assert.Equal(t, errInternal, body.Error)
 }
 
 func TestAddBook(t *testing.T) {
 	mockService := new(services.MockBooksService)
-	mockService.On("SaveBook", mock.Anything, domain.Book{Title: "Title"}).Return(nil)
+	mockService.On("SaveBook", mock.Anything, domain.Book{Title: bookTitle}).Return(nil)
 
 	app := fiber.New()
 	app.Post(booksRoute, AddBook(mockService))
@@ -81,7 +84,7 @@ func TestAddBook_InvalidRequest(t *testing.T) {
 
 func TestAddBook_ServiceFails(t *testing.T) {
 	mockService := new(services.MockBooksService)
-	mockService.On("SaveBook", mock.Anything, domain.Book{Title: "Title"}).Return(assert.AnError)
+	mockService.On("SaveBook", mock.Anything, domain.Book{Title: bookTitle}).Return(assert.AnError)
 
 	app := fiber.New()
 	app.Post(booksRoute, AddBook(mockService))
@@ -92,7 +95,7 @@ func TestAddBook_ServiceFails(t *testing.T) {
 	defer resp.Body.Close()
 
 	body := bodyFromResponse[domain.ErrorResponse](t, resp)
-	assert.Equal(t, "internal error", body.Error)
+	assert.Equal(t, errInternal, body.Error)
 }
 
 func postRequest(ctx context.Context, url string, body string) *http.Request {

--- a/fiber-postgres/app/server/server_test.go
+++ b/fiber-postgres/app/server/server_test.go
@@ -15,7 +15,7 @@ import (
 func TestGetStatus(t *testing.T) {
 	app := NewServer(&datasources.DataSources{})
 
-	resp, err := app.Test(httptest.NewRequest(http.MethodGet, "/api/status", nil))
+	resp, err := app.Test(httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/status", nil))
 	require.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
 	defer resp.Body.Close()

--- a/fiber-postgres/app/server/services/books_test.go
+++ b/fiber-postgres/app/server/services/books_test.go
@@ -12,9 +12,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const bookTitle = "Title"
+
 func TestGetBooks(t *testing.T) {
 	mockDB := new(database.MockDatabase)
-	mockDB.On("LoadAllBooks", mock.Anything).Return([]database.Book{{Title: "Title"}}, nil)
+	mockDB.On("LoadAllBooks", mock.Anything).Return([]database.Book{{Title: bookTitle}}, nil)
 
 	service := NewBooksService(mockDB)
 	books, err := service.GetBooks(context.Background())
@@ -33,18 +35,18 @@ func TestGetBooks_Fails(t *testing.T) {
 
 func TestSaveBook(t *testing.T) {
 	mockDB := new(database.MockDatabase)
-	mockDB.On("CreateBook", mock.Anything, database.NewBook{Title: "Title"}).Return(nil)
+	mockDB.On("CreateBook", mock.Anything, database.NewBook{Title: bookTitle}).Return(nil)
 
 	service := NewBooksService(mockDB)
-	err := service.SaveBook(context.Background(), domain.Book{Title: "Title"})
+	err := service.SaveBook(context.Background(), domain.Book{Title: bookTitle})
 	require.NoError(t, err)
 }
 
 func TestSaveBook_Fails(t *testing.T) {
 	mockDB := new(database.MockDatabase)
-	mockDB.On("CreateBook", mock.Anything, database.NewBook{Title: "Title"}).Return(assert.AnError)
+	mockDB.On("CreateBook", mock.Anything, database.NewBook{Title: bookTitle}).Return(assert.AnError)
 
 	service := NewBooksService(mockDB)
-	err := service.SaveBook(context.Background(), domain.Book{Title: "Title"})
+	err := service.SaveBook(context.Background(), domain.Book{Title: bookTitle})
 	assert.Error(t, err)
 }

--- a/rest-api/go.mod
+++ b/rest-api/go.mod
@@ -1,3 +1,3 @@
 module app
 
-go 1.23.3
+go 1.26.3

--- a/rest-api/server/handlers/books.go
+++ b/rest-api/server/handlers/books.go
@@ -9,13 +9,15 @@ import (
 	"app/server/services"
 )
 
+const errInternal = "internal error"
+
 func GetBooks(service services.BooksService) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		books, err := service.GetBooks(r.Context())
 		if err != nil {
 			slog.Error("GetBooks failed", "error", err)
 			sendJSON(w, http.StatusInternalServerError, domain.ErrorResponse{
-				Error: "internal error",
+				Error: errInternal,
 			})
 			return
 		}
@@ -43,7 +45,7 @@ func AddBook(service services.BooksService) func(w http.ResponseWriter, r *http.
 		if err != nil {
 			slog.Error("AddBook failed", "error", err)
 			sendJSON(w, http.StatusInternalServerError, domain.ErrorResponse{
-				Error: "internal error",
+				Error: errInternal,
 			})
 			return
 		}
@@ -55,7 +57,7 @@ func sendJSON(w http.ResponseWriter, code int, response any) {
 	jsonResponse, err := json.Marshal(response)
 	if err != nil {
 		slog.Error("sendResponse json.Marshal failed", "error", err)
-		http.Error(w, "internal error", http.StatusInternalServerError)
+		http.Error(w, errInternal, http.StatusInternalServerError)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -63,6 +65,6 @@ func sendJSON(w http.ResponseWriter, code int, response any) {
 	_, err = w.Write(jsonResponse)
 	if err != nil {
 		slog.Error("sendResponse w.Write failed", "error", err)
-		http.Error(w, "internal error", http.StatusInternalServerError)
+		http.Error(w, errInternal, http.StatusInternalServerError)
 	}
 }

--- a/rest-api/server/handlers/books_test.go
+++ b/rest-api/server/handlers/books_test.go
@@ -25,7 +25,7 @@ func TestGetBooks(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc(booksRoute, GetBooks(mockService))
 
-	req := httptest.NewRequest(http.MethodGet, booksRoute, nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, booksRoute, nil)
 	resp := httptest.NewRecorder()
 	mux.ServeHTTP(resp, req)
 
@@ -51,7 +51,7 @@ func TestGetBooks_ServiceFails(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc(booksRoute, GetBooks(mockService))
 
-	req := httptest.NewRequest(http.MethodGet, booksRoute, nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, booksRoute, nil)
 	resp := httptest.NewRecorder()
 	mux.ServeHTTP(resp, req)
 
@@ -77,7 +77,7 @@ func TestAddBook(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc(booksRoute, AddBook(mockService))
 
-	req := postRequest(booksRoute, `{"title":"Title"}`)
+	req := postRequest(t.Context(), booksRoute, `{"title":"Title"}`)
 	resp := httptest.NewRecorder()
 	mux.ServeHTTP(resp, req)
 
@@ -92,7 +92,7 @@ func TestAddBook_InvalidRequest(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc(booksRoute, AddBook(mockService))
 
-	req := httptest.NewRequest(http.MethodPost, booksRoute, nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, booksRoute, nil)
 	resp := httptest.NewRecorder()
 	mux.ServeHTTP(resp, req)
 
@@ -118,7 +118,7 @@ func TestAddBook_ServiceFails(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc(booksRoute, AddBook(mockService))
 
-	req := postRequest(booksRoute, `{"title":"Title"}`)
+	req := postRequest(t.Context(), booksRoute, `{"title":"Title"}`)
 	resp := httptest.NewRecorder()
 	mux.ServeHTTP(resp, req)
 
@@ -134,8 +134,8 @@ func TestAddBook_ServiceFails(t *testing.T) {
 	}
 }
 
-func postRequest(url string, body string) *http.Request {
-	req := httptest.NewRequest(http.MethodPost, url, bytes.NewBufferString(body))
+func postRequest(ctx context.Context, url string, body string) *http.Request {
+	req := httptest.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBufferString(body))
 	req.Header.Set("Content-Type", "application/json")
 	return req
 }

--- a/rest-api/server/handlers/books_test.go
+++ b/rest-api/server/handlers/books_test.go
@@ -62,8 +62,8 @@ func TestGetBooks_ServiceFails(t *testing.T) {
 	defer result.Body.Close()
 
 	body := bodyFromResponse[domain.ErrorResponse](t, result)
-	if body.Error != "internal error" {
-		t.Fatalf("expected error message 'internal error', got '%s'", body.Error)
+	if body.Error != errInternal {
+		t.Fatalf("expected error message %q, got %q", errInternal, body.Error)
 	}
 }
 
@@ -129,8 +129,8 @@ func TestAddBook_ServiceFails(t *testing.T) {
 	defer result.Body.Close()
 
 	respBody := bodyFromResponse[domain.ErrorResponse](t, result)
-	if respBody.Error != "internal error" {
-		t.Fatalf("expected error message 'internal error', got '%s'", respBody.Error)
+	if respBody.Error != errInternal {
+		t.Fatalf("expected error message %q, got %q", errInternal, respBody.Error)
 	}
 }
 

--- a/rest-api/server/server_test.go
+++ b/rest-api/server/server_test.go
@@ -11,7 +11,7 @@ import (
 func TestGetStatus(t *testing.T) {
 	app := NewServer(&datasources.DataSources{})
 
-	req := httptest.NewRequest(http.MethodGet, "/api/status", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/status", nil)
 	resp := httptest.NewRecorder()
 	app.ServeHTTP(resp, req)
 

--- a/rest-api/server/services/books_test.go
+++ b/rest-api/server/services/books_test.go
@@ -9,10 +9,12 @@ import (
 	"app/server/domain"
 )
 
+const bookTitle = "Title"
+
 func TestGetBooks(t *testing.T) {
 	mockDB := &database.MockDatabase{
 		LoadAllBooksFunc: func(_ context.Context) ([]database.Book, error) {
-			return []database.Book{{Title: "Title"}}, nil
+			return []database.Book{{Title: bookTitle}}, nil
 		},
 	}
 
@@ -48,7 +50,7 @@ func TestSaveBook(t *testing.T) {
 	}
 
 	service := NewBooksService(mockDB)
-	err := service.SaveBook(context.Background(), domain.Book{Title: "Title"})
+	err := service.SaveBook(context.Background(), domain.Book{Title: bookTitle})
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -62,7 +64,7 @@ func TestSaveBook_Fails(t *testing.T) {
 	}
 
 	service := NewBooksService(mockDB)
-	err := service.SaveBook(context.Background(), domain.Book{Title: "Title"})
+	err := service.SaveBook(context.Background(), domain.Book{Title: bookTitle})
 	if err == nil {
 		t.Fatalf("expected error, got nil")
 	}


### PR DESCRIPTION
- migrate root .golangci.yml from v1 to v2 format (via `golangci-lint migrate`)
- bump test_all.yml to golangci-lint-action v9.2.0 with latest linter
- bump fiber-postgres/app and rest-api modules to Go 1.26.3